### PR TITLE
brill: #16764 – korean script

### DIFF
--- a/src/coco-script.dtx
+++ b/src/coco-script.dtx
@@ -155,6 +155,24 @@
     WordSpace = 1.25]{NotoSansJP-Regular.otf}
   }
 %    \end{macrocode}
+% \subsection{Support for Korean script}
+%    \begin{macrocode}
+\tpDeclareBabelFont{korean}{[%
+  BoldFont = NotoSerifKR-Bold.otf,%
+  ItalicFont = NotoSerifKR-Regular.otf,%
+  BoldItalicFont = NotoSerifKR-Medium.otf,%
+  Path=./fonts/Noto/Korean/,%
+  Script=CJK%
+  ]{NotoSerifKR-Regular.otf}}
+{[%
+  BoldFont = NotoSansKR-Bold.otf,%
+  ItalicFont = NotoSansKR-Regular.otf,%
+  BoldItalicFont = NotoSansKR-Medium.otf,%
+  Path=./fonts/Noto/Korean/,%
+  Script=CJK%
+  ]{NotoSansKR-Regular.otf}%
+}
+%    \end{macrocode}
 % \subsection{Support for Hebrew script}
 %    \begin{macrocode}
 \tpDeclareBabelFont{hebrew}{[%


### PR DESCRIPTION
Anlässlich von [16764](https://redmine.le-tex.de/issues/16764):

`\tpDeclareBabelFont{korean}` hinzugefügt; 
Zeile `Script=CJK` aus `vundrlay.sty` übernommen, welches auch diese Font nutzt. Dort war kein `WordSpace = 1.25` verwendet, weshalb ich es hier zunächst auch weglasse.

Bitte prüfen.