### PR TITLE
added methods to tag foreign language passages

### DIFF
--- a/externals/ltpdfa/ltpdfa/pdfwriter.lua
+++ b/externals/ltpdfa/ltpdfa/pdfwriter.lua
@@ -199,7 +199,12 @@ local function structElems(childs, ppdfobj)
             end
             nstr = nstr .. astr .. "] "
          end
-         nstr = nstr .. "/K [".. kids .."] >>"
+         nstr = nstr .. "/K [".. kids .."]"
+	 if (v.language) then
+	    local lstr = " /Lang(".. v.language ..")"
+	    nstr = nstr .. lstr
+	 end
+	 nstr = nstr .. " >>"
          pdfobj = pdf.immediateobj(pdfobj, nstr)
       else
          cstr = cstr .. "<</Type /MCR /Pg " .. pdf.pageref(v.startpage) .. " 0 R /MCID " .. v.mcid .. " >> "

--- a/externals/ltpdfa/ltpdfa/structelem.lua
+++ b/externals/ltpdfa/ltpdfa/structelem.lua
@@ -43,6 +43,7 @@ function StructElem:new(type)
    elem.startpage = 0
    elem.lastUsed  = 0 -- remember last child, some mcid was added
    elem.created   = false
+   elem.language  = false
    return elem
 end
 -- remove child or nothing, return next free
@@ -165,6 +166,10 @@ function StructElem:addToAttributes(key, arg)
    table.insert(self.attributes[key], arg)
    --log("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ %s", self.idx)
    --dumpArray(self.attributes.Table)
+end
+
+function StructElem:addLanguage(lang)
+   self.language = lang
 end
 
 function StructElem:hasContentChilds()

--- a/externals/ltpdfa/ltpdfa/tagger.lua
+++ b/externals/ltpdfa/ltpdfa/tagger.lua
@@ -212,6 +212,10 @@ local function addNumbering(name)
    stree.current:addToAttributes('List','/ListNumbering/' .. name)
 end
 
+local function addLanguage(val)
+   stree.current:addLanguage(val)
+end
+
 local function figureStart()
    structtree.savePosStart()
 end
@@ -265,6 +269,7 @@ local inputtagger = {
    addLastLink     = structtree.addLastLink,
    addNumbering    = addNumbering,
    addPlacement    = addPlacement,
+   addLanguage     = addLanguage,
    addToStruct     = structtree.addToStruct,
    doautoclose     = doautoclose,
    getCurrentStruct= structtree.getCurrentStruct,

--- a/src/coco-accessibility.dtx
+++ b/src/coco-accessibility.dtx
@@ -503,6 +503,33 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \subsection{Language Tagging}
+%
+% \begin{macro}{\ccaAddLang} adds a \texttt{/Lang}(uage) attribute to
+%   the current node with the value \InlineArg{1}.
+%    \begin{macrocode}
+\DeclareAccessibilityCommand{\ccaAddLang}[1]{\directlua{ltpdfa.tagger.addLanguage('\luaescapestring{#1}')}}
+%    \end{macrocode}
+% \end{macro}
+% The following code patches the unstarred
+% \lstinline{\foreignlanguage} command in such a way that it
+% automatically tags its content with a \UsageTag{/Span} and adds a
+% \lstinline{/Lang} attribute to the Tag that is colleted from the
+% language definition file of the currently activated language.
+%    \begin{macrocode}
+\ccWhenAlly{%
+  \AddToHook{babel/*/foreign}{%
+    \pretocmd\BabelText
+      {\ccaVstructStart{Span}\ccaAddLang{\localeinfo{tag.bcp47}}}
+      {}{\cca@patch@error\BabelText}%
+    \apptocmd\BabelText
+      {\ccaVstructEnd{Span}}
+      {}{\cca@patch@error\BabelText}%
+    }%
+  \AtBeginDocument{\ActivateGenericHook{babel/*/foreign}}%
+}% /ccWhenAlly
+%    \end{macrocode}
+%
 %
 % \subsection{Lua injection}
 %


### PR DESCRIPTION
Added lua method to ltpdfa to add a `/Lang` to an existing tag and the corresponding tex interface. For now, we hook only into an unstarred `\foreignlanguage`, with more to follow eventually.