### PR TITLE
Fix: prevent PDF compilation failing due to missing Number component in the processed heading

### DIFF
--- a/src/coco-notes.dtx
+++ b/src/coco-notes.dtx
@@ -247,7 +247,8 @@
       \ccn@end@enotes
       \global\advance\realchap\@ne
       \ifx\ccn@reset@notes@per@chapter\relax\global\c@endnote\z@\fi
-      \def\ccn@par@number{\ccIfComp{TocNumber}{\ccUseComp{TocNumber}}{\ccUseComp{Number}}}%
+      % If headings don’t provide a Number component, the PDF compilation will fail when generating the endnotes with chapter headings, so \relax has to be a fallback value.
+      \def\ccn@par@number{\ccIfComp{TocNumber}{\ccUseComp{TocNumber}}{\ccIfComp{Number}{\ccUseComp{Number}}{\relax}}}%
       \def\ccn@par@title{\ccIfComp{TocTitle}{\ccUseComp{TocTitle}}{\ccUseComp{Title}}}%
       \def\ccn@par@runtitle{\ccIfComp{RunTitle}{\ccUseComp{RunTitle}}{\ccUseComp{Title}}}%
       \addtoendnotes{%

--- a/src/coco-notes.dtx
+++ b/src/coco-notes.dtx
@@ -13,7 +13,9 @@
 %%
 %% Maintainer: p.schulz@le-tex.de
 %%
-\NeedsTeXFormat{LaTeX2e}[]
+%% lualatex  -  texlive > 2019
+%%
+\NeedsTeXFormat{LaTeX2e}[2020/06/01]
 \ProvidesPackage{coco-notes}
     [\filedate \fileversion le-tex coco notes module]
 %    \end{macrocode}
@@ -36,47 +38,39 @@
 %
 % The \lstinline{endnotes} option causes all footnotes to be rendered as endnotes.
 %    \begin{macrocode}
-\ExplSyntaxOn
-\keys_define:nn { cocotex/notes }
-{
-  endnotes .code:n = { \global\@ccn@use@entrue },
+\DeclareOption{endnotes}{\global\@ccn@use@entrue}
 %    \end{macrocode}
 % The option \lstinline{ennotoc} prevents headings in the Notes
 % section from creating entries in the Table of Contents.
 %    \begin{macrocode}
-  ennotoc  .code:n = { \global\let\ccn@en@no@toc\relax },
+\DeclareOption{ennotoc}{\global\let\ccn@en@no@toc\relax}
 %    \end{macrocode}
 % The option \lstinline{resetnotesperchapter} resets foot- and endnote
 % counters at the start of each \lstinline{chapter} level heading. If
 % omitted (default) foot- or endnotes are numbered throughout the
 % whole document
 %    \begin{macrocode}
-  resetnotesperchapter .code:n = { \global\let\ccn@reset@notes@per@chapter\relax },
+\DeclareOption{resetnotesperchapter}{\global\let\ccn@reset@notes@per@chapter\relax}
 %    \end{macrocode}
 % The option \lstinline{endnoteswithchapters} implies
 % \lstinline{endnotes} and causes chapter headings to be repeated in
 % the printnotes chapter as sections.
 %    \begin{macrocode}
-  endnoteswithchapters .code:n =
-  {
-    \global\@ccn@use@entrue
-    \global\let\ccn@en@with@chapters\relax
-  },
+\DeclareOption{endnoteswithchapters}{\global\@ccn@use@entrue\global\let\ccn@en@with@chapters\relax}
 %    \end{macrocode}
 % The option \lstinline{endnotelinks} is now defunct, because
 % back-linking is necessary for tagging.
 %    \begin{macrocode}
-  endnotelinks .code:n = {}
-}
-\ProcessKeyOptions[cocotex/notes]
-\ExplSyntaxOff
+\DeclareOption{endnotelinks}{}
+\ProcessOptions
 %    \end{macrocode}
 %
 %
 % \subsection{Hard Requirements}
 %
 % The \lstinline{footnote} package is mandatory since it provides the
-% \lstinline{\savenotes} and \lstinline{\spewnotes} macros.
+% \lstinline{\savenotes} and \lstinline{\spewnotes} macros needed in
+% other {\CoCoTeX} modules.
 %    \begin{macrocode}
 \RequirePackage{footnote}
 %    \end{macrocode}


### PR DESCRIPTION
When generating headings for endnote chapters, the PDF compilation hangs, if the heading does not provide a `\tpNumber{…}` component. This pull request contains the application of a fallback value for such cases. The returned `\relax` handling can then be done in the customer style files.