### PR TITLE
Fixing that each document will return true for \ifmonograph besides \if[pubtype]

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -5,8 +5,8 @@ patch = "0"
 
 [date]
 year = "2025"
-month = "01"
-day = "30"
+month = "02"
+day = "07"
 
 [tex]
 year = "2023"

--- a/src/cocotex.dtx
+++ b/src/cocotex.dtx
@@ -90,12 +90,12 @@
 \newif\ifjournal    \journalfalse
 \keys_define:nn { cocotex/cls }
 {
+  pubtype           .initial:n = mono,
   pubtype .choice:,
   pubtype / collection .code:n = { \global\collectiontrue },
   pubtype / article    .code:n = { \global\articletrue    },
   pubtype / journal    .code:n = { \global\journaltrue    },
   pubtype / mono       .code:n = { \global\monographtrue  },
-  pubtype           .initial:n = mono,
 }
 %    \end{macrocode}
 %


### PR DESCRIPTION
Hi, @LupinoTech.

I found an issue with the pubtype parameter in the CoCoTeX document class. With the current pubtype choice definition, where the initial/default value is `mono`, `\ifmonograph` will always return `true`, no matter which pubtype has been set in the document parameters. However, the `\if[pubtype]` that corresponds to the set pubtype will also return `true`. Putting the initial value `mono` for the respective choice key to the top fixes that issue.

Please evaluate that and merge if you can confirm that my fix is valid. An MWE for testing the issue is below:
```
% 
\documentclass[english,french,swedish,danish,portuguese,greek,main=ngerman,pubtype=collection]{cocotex}
\usepackage{htmltabs}
\usepackage[format=print,layout=170,verlag=vr, authorbioposition=placed, abstractposition=placed, logoColorsQnt=1]{vr}

\begin{tpMeta}
\end{tpMeta}

\begin{document}

\ifcollection
  \typeout{++++++++++++++++++++++ It’s a collection!}%
\fi
\ifarticle
  \typeout{++++++++++++++++++++++ It’s an article!}%
\fi
\ifjournal
  \typeout{++++++++++++++++++++++ It’s a journal!}%
\fi
\ifmonograph
  \typeout{++++++++++++++++++++++ It’s a monograph!}%
\fi

\end{document}
```

Kind regards,
Marcus