### PR TITLE
added \texthashchar macro for literal hash characters, especially in …

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -4,9 +4,9 @@ minor = "6"
 patch = "2"
 
 [date]
-year = "2025"
-month = "07"
-day = "24"
+year = "2026"
+month = "02"
+day = "03"
 
 [tex]
 year = "2023"

--- a/src/coco-headings.dtx
+++ b/src/coco-headings.dtx
@@ -1746,6 +1746,16 @@
 \letcs\TitleBreak{\ccPrefix Break}
 %    \end{macrocode}
 % \end{macro}
+% \begin{macro}{\texthashchar} prints a hash character (#), which is
+%   especially supposed to be used for the \tpBMTitle{…} macro, in case
+%   the authors want/need a literal hash character in the PDF bookmark.
+%    \begin{macrocode}
+\begingroup
+  \catcode `\#=\active\gdef#{\string#}
+  \gdef\texthashchar{\string#}%
+\endgroup
+%    \end{macrocode}
+% \end{macro}
 %    \begin{macrocode}[numbers=none,gobble=1]
 %</headings>
 %    \end{macrocode}


### PR DESCRIPTION
…PDF bookmarks