### PR TITLE
mapped \texttt{…} to Noto fallback font

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -6,7 +6,7 @@ patch = "3"
 [date]
 year = "2026"
 month = "02"
-day = "13"
+day = "16"
 
 [tex]
 year = "2023"

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,7 @@ export COCOTEX_SRC=$(dirname $(readlink -f $0))
 export CUR_PWD=`pwd`
 cd $COCOTEX_SRC/lib/ruby
 
-#bundle config --local without development
-#bundle config set --local frozen 'true'
-#bundle check > /dev/null || bundle install
-#bundle exec ruby frontend.rb $*
-ruby frontend.rb $*
+bundle config --local without development
+bundle config set --local frozen 'true'
+bundle check > /dev/null || bundle install
+bundle exec ruby frontend.rb $*

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,8 @@ export COCOTEX_SRC=$(dirname $(readlink -f $0))
 export CUR_PWD=`pwd`
 cd $COCOTEX_SRC/lib/ruby
 
-bundle config --local without development
-bundle config set --local frozen 'true'
-bundle check > /dev/null || bundle install
-bundle exec ruby frontend.rb $*
+#bundle config --local without development
+#bundle config set --local frozen 'true'
+#bundle check > /dev/null || bundle install
+#bundle exec ruby frontend.rb $*
+ruby frontend.rb $*

--- a/src/coco-script.dtx
+++ b/src/coco-script.dtx
@@ -147,6 +147,11 @@
 \DeclareTextFontCommand\textttfallback{\ttfallbackfont}
 %    \end{macrocode}
 % \end{macro}
+% \texttt is mapped to Noto to support a large amount of glyphs
+% that are neither supported by Computer Modern Mono nor Latin Modern Mono.
+%    \begin{macrocode}
+\let\ttfamily\ttfallbackfont
+%    \end{macrocode}
 % \begin{macro}{\ccFallback} is a ``smart'' font macro that detects if
 %   it has been used inside \texttt{rm}, \texttt{sf}, or \texttt{tt}
 %   contexts and switches to the corresponding fallback font


### PR DESCRIPTION
`\ttfamily` now has the functionality of `\ttfallbackfont`.