### PR TITLE
extended the OutputIntents field by /Info

### DIFF
--- a/externals/ltpdfa/ltpdfa/pdfwriter.lua
+++ b/externals/ltpdfa/ltpdfa/pdfwriter.lua
@@ -334,7 +334,7 @@ local function intent(head)
       debug_log("Using profile %s", filename)
    end
    local iccstream = pdf.immediateobj("streamfile", filename, "/N " .. config.intent.components)
-   local nstr = "<</Type/OutputIntent /RegistryName(http://www.color.org) /S/GTS_PDFA1 /OutputCondition() /OutputConditionIdentifier (" .. config.intent.identifier .. ") /DestOutputProfile " .. iccstream .. " 0 R>>"
+   local nstr = "<</Type/OutputIntent /RegistryName(http://www.color.org) /Info (" .. config.intent.identifier .. ") /S/GTS_PDFA1 /OutputCondition() /OutputConditionIdentifier (" .. config.intent.identifier .. ") /DestOutputProfile " .. iccstream .. " 0 R>>"
    local intentobjnum = pdf.immediateobj(nstr)
    pdf.setcatalog( '/OutputIntents [ ' .. intentobjnum .. ' 0 R ]')
 end


### PR DESCRIPTION
As agreed upon with a customer, the PDF `OutputIntent` data has been extended with the `/Info` field to produce the desired output that has been requested by the customer’s print shop and which had also been set by this customer’s style file before switching to the `a11y` branch.